### PR TITLE
Set MoCap Mouse LSL stream to irregular_srate

### DIFF
--- a/src/fr/lgi2p/digit/conf/Consts.java
+++ b/src/fr/lgi2p/digit/conf/Consts.java
@@ -4,7 +4,7 @@ public final class Consts {
 
 	public static final String APP_NAME = "mouseReMoCo";
 
-	public static final String APP_VERSION = "1.2.4";
+	public static final String APP_VERSION = "1.2.5";
 
 	public static final double INCH_PER_MM = 25.4;
 	

--- a/src/fr/lgi2p/digit/output/OutputMouse.java
+++ b/src/fr/lgi2p/digit/output/OutputMouse.java
@@ -88,7 +88,8 @@ public class OutputMouse {
 	private void SetDataOutlet(Configuration configuration) throws IOException {
 		// We make a stream of type MoCap with 3 channels 
 		// StreamInfo(name, type, channel_count, nominal_srate, channel_format, source_id)
-		LSL.StreamInfo info = new LSL.StreamInfo(streamNameLSL+"Data","MoCap",3,100,LSL.ChannelFormat.float32, Consts.APP_NAME);
+		// LSL.StreamInfo info = new LSL.StreamInfo(streamNameLSL+"Data","MoCap",3,100,LSL.ChannelFormat.float32, Consts.APP_NAME);
+		LSL.StreamInfo info = new LSL.StreamInfo(streamNameLSL+"Data", "MoCap", 3, LSL.IRREGULAR_RATE, LSL.ChannelFormat.float32, Consts.APP_NAME);
 
 		// meta info : channels 
 		// https://github.com/sccn/xdf/wiki/MoCap-Meta-Data 


### PR DESCRIPTION
Before the correction, in the figures below, we see that the data is resampled at 49.6194 Hz (with a warning that this is different from the specified rate of 100 Hz). 
<img width="575" alt="Capture d’écran 2023-07-22 à 15 56 18" src="https://github.com/DenisMot/mouseReMoCo/assets/28569898/35f5ad1d-7557-4f61-979c-6588f7050449">
<img width="578" alt="Capture d’écran 2023-07-22 à 15 55 45" src="https://github.com/DenisMot/mouseReMoCo/assets/28569898/1a177958-b18a-4783-9e43-fcd760ec6b8f">


The `MouseData` LSL stream is now declared with `LSL.IRREGULAR_RATE`. 
Test with LabRecorder shows that the irregular rate allows to get correct timestamps in XDF files. 
This allows to get proper time stamps, as illustrated below 

<img width="581" alt="Capture d’écran 2023-07-22 à 16 22 41" src="https://github.com/DenisMot/mouseReMoCo/assets/28569898/17d8afd4-79a6-4add-9fda-7eb83b81f891">
<img width="580" alt="Capture d’écran 2023-07-22 à 16 22 31" src="https://github.com/DenisMot/mouseReMoCo/assets/28569898/c52ddf6c-fd24-4c43-9b9e-b94e8f55c468">
