### PR TITLE
13 creation date is missing in lsl streams

### DIFF
--- a/src/fr/lgi2p/digit/output/OutputMouse.java
+++ b/src/fr/lgi2p/digit/output/OutputMouse.java
@@ -117,8 +117,8 @@ public class OutputMouse {
 		info.desc().append_child("acquisition")
 		.append_child_value("manufacturer","EuroMov")
 		.append_child_value("software",Consts.APP_NAME)
-		.append_child_value("version",Consts.APP_VERSION)
-		.append_child_value("task",configuration.getTaskString());
+		.append_child_value("version",Consts.APP_VERSION);
+		//.append_child_value("task",configuration.getTaskString());
 
 		// meta info : configuration   
 		LSL.XMLElement config = info.desc().append_child("configuration");

--- a/src/fr/lgi2p/digit/output/OutputMouse.java
+++ b/src/fr/lgi2p/digit/output/OutputMouse.java
@@ -59,7 +59,7 @@ public class OutputMouse {
 
 			// Send with LSL : prepare a stream for mouse output 
 			if (isWithLSL) {
-				SetDataOutlet(configuration);
+				SetDataOutlet(configuration, logDate);
 				SetMarkerOutlet(configuration);
 			} 
 
@@ -85,7 +85,7 @@ public class OutputMouse {
 		return withLSL;
 	}
 
-	private void SetDataOutlet(Configuration configuration) throws IOException {
+	private void SetDataOutlet(Configuration configuration, String creationDateString) throws IOException {
 		// We make a stream of type MoCap with 3 channels 
 		// StreamInfo(name, type, channel_count, nominal_srate, channel_format, source_id)
 		// LSL.StreamInfo info = new LSL.StreamInfo(streamNameLSL+"Data","MoCap",3,100,LSL.ChannelFormat.float32, Consts.APP_NAME);
@@ -128,6 +128,10 @@ public class OutputMouse {
 			config.append_child_value(configurationKeyValue[0], configurationKeyValue[1]);
 			//System.out.println(configurationKeyValue[0] +" = "+ configurationKeyValue[1]);
 		}
+
+		// meta info : creation date as in CSV files 
+		info.desc().append_child("creation")
+		.append_child_value("creationDateString", creationDateString);
 
 		// create the stream with all the preceding information
 		dataOutlet = new LSL.StreamOutlet(info);


### PR DESCRIPTION
Changes : 
1. Creation date is added  at the end of `desc` : 
``` 
[MouseData]
 info
     desc
         channels ...
         acquisition ...
         configuration...
         creation
             creationDateString: 2023-07-22 21:14:23.661 +0200
```

1. Suppression of `task` in `desc.acquisition` (task belongs to config where it already is)
