### PR TITLE
15 data should be saved during pause

### DIFF
--- a/src/fr/lgi2p/digit/MainWindow.java
+++ b/src/fr/lgi2p/digit/MainWindow.java
@@ -343,15 +343,22 @@ public final class MainWindow implements MouseMotionListener, MouseListener, Key
 		}
 	}
 
+	private void setMouseMotionListener() {
+		MouseListener [] ml = frame.getMouseListeners();
+		if (ml.length == 0) {
+			frame.addMouseListener(this);
+			frame.addMouseMotionListener(this);
+		}
+	}
+
 	private void toggleRecordPause() {
 		if (this.recording) {
 			this.NbRestDone = this.NbRestDone + 1;
-			frame.removeMouseListener(this);
-			frame.removeMouseMotionListener(this);
+			// frame.removeMouseListener(this);
+			// frame.removeMouseMotionListener(this);
 		} else {
 			this.NbRecDone = this.NbRecDone + 1;
-			frame.addMouseListener(this);
-			frame.addMouseMotionListener(this);
+			setMouseMotionListener();
 		}
 		this.recording = !this.recording;
 
@@ -406,15 +413,15 @@ public final class MainWindow implements MouseMotionListener, MouseListener, Key
 		}
 
 		// pass the job to output and performance analysis
-		if (this.recording) {
+		// if (this.recording) {
+		if (true) { // issue #15 : always record, even if not recording
 			// only if position changed, record and analyze the data
 			// this saves about 50% of the output (
 			if (X != previousX | Y != previousY) {
-				// if (true) {
 				previousX = X;
 				previousY = Y;
 				outputMouse.writeData(T, X, Y, isInside);
-				if (performanceAtTask != null)
+				if (performanceAtTask != null & this.recording)
 					performanceAtTask.mouseMoved(T, X, Y, isInside, d);
 			}
 		}

--- a/src/fr/lgi2p/digit/conf/Consts.java
+++ b/src/fr/lgi2p/digit/conf/Consts.java
@@ -4,7 +4,7 @@ public final class Consts {
 
 	public static final String APP_NAME = "mouseReMoCo";
 
-	public static final String APP_VERSION = "1.2.5";
+	public static final String APP_VERSION = "1.3.0";
 
 	public static final double INCH_PER_MM = 25.4;
 	


### PR DESCRIPTION
In this release candidate of version 1.3, data recording  (i.e., CSV logging + LSL streaming): 
- starts with the first "record" phase 
- does not stop during the "pause" phases

This has been tested with the CSV files on a MacBook (see figure below). 
Download [mouseReMoCo.1.3.0.rc01.jar.zip](https://github.com/DenisMot/mouseReMoCo/files/12330143/mouseReMoCo.1.3.0.rc01.jar.zip)
Next tests should target LSL and PC, ideally. 


In the figure below, the red vertical lines indicate the beginning of a "pause" phase (blue  = beginning of a "record" phase). 

![image](https://github.com/DenisMot/mouseReMoCo/assets/28569898/ce86e631-3b1f-4a0e-954f-b8d196b37060)


